### PR TITLE
Fix skipping tests break in the test runner

### DIFF
--- a/service/src/jestSetup/screenshotReporter.js
+++ b/service/src/jestSetup/screenshotReporter.js
@@ -29,7 +29,7 @@ class PuppeteerScreenshotReporter {
         for (let result of testResult.testResults) {
             const relativePath = path.join(result.fullName, this._options.filename || 'screenshot.png')
             const screenshot = path.join(this._options.output, relativePath)
-            if (result.status !== 'passed') {
+            if (result.status === 'failed') {
                 const downloadLink = await this.uploadScreenshotToS3(screenshot)
 
                 result.failureMessages.push(`Screenshot available at ${relativePath}`)


### PR DESCRIPTION
If we use `skip` in the test files, the test runner will throw error. This is because we are assuming screenshots always exist if a test does not pass, so it tries to find screenshot in the skipped test too.