### PR TITLE
doesnt need to be async

### DIFF
--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -8,7 +8,7 @@ const xml2js = require('xml2js')
  * @param {string} variable
  * @param {object} variableMap
  */
-const collectVariables = async (variable, variableMap) => {
+const collectVariables = (variable, variableMap) => {
     const equalPos = variable.indexOf('=')
     if (equalPos < 0) {
         return variableMap


### PR DESCRIPTION
related to issue #50 

because its running in async, the dictionary it returns is a promise. Doesnt need to be ran in async, and this will allow passing in vars via --var to work again :) 