### PR TITLE
adds exclude flag + renames test-path-pattern to include

### DIFF
--- a/client/src/cli.js
+++ b/client/src/cli.js
@@ -13,8 +13,9 @@ const CONFIG_OPTIONS = [
     'lambdaFunction',
     'outputDir',
     'testDir',
-    'testPathPattern',
+    'include',
     'var',
+    'exclude',
 ]
 const DEFAULT_FUNCTION_NAME = 'sanity-runner-dev-default'
 const DEFAULT_TEST_DIR = '.'
@@ -27,7 +28,14 @@ program
         'configuration file, in the JSON syntax. It specifies how to find ' +
         'and execute tests. It will overridden if the corresponding flag values.')
     .option('--test-dir <directory>', 'Test suites directory')
-    .option('--test-path-pattern <regexForTestFiles>', 'Run only tests with paths matching the given regex')
+    .option(
+        '--include <regexForTestFiles>', 
+        'Have the client ONLY run test files matching the supplied regex'
+    )
+    .option(
+        '--exclude <regexForTestFiles>',
+        'Have the client ignore NOT run test files matching the supplied regex',
+    )    
     .option(
         '--lambda-function [functionName]',
         `The AWS Lambda function name. Default to ${DEFAULT_FUNCTION_NAME} if omitted.`
@@ -50,21 +58,25 @@ const testFileNames = glob.sync('**/*.js', { cwd: testDir })
 
 console.log(`Reading test files in ${testDir}...`)
 
-const testPathsRegex = configuration.testPathPattern ? new RegExp(configuration.testPathPattern) : null
+const includeRegex = configuration.include ? new RegExp(configuration.include) : null
+const excludeRegex = configuration.exclude ? new RegExp(configuration.exclude) : null
+
 const testFiles = testFileNames.reduce((payload, filename) => {
     const filePath = path.join(testDir, filename)
-    if (testPathsRegex && !testPathsRegex.test(filePath))
+    if ((includeRegex && !includeRegex.test(filePath)) || (excludeRegex && excludeRegex.test(filePath)))
         return payload
-
+        
     console.log(`- ${filename}`)
     const fileContent = fs.readFileSync(filePath, 'utf8')
     return Object.assign(payload, { [filename]: fileContent })
 }, {})
 
 if (Object.keys(testFiles).length === 0) {
-    if (testPathsRegex) {
-        console.log(`No test file is found matching "${configuration.testPathPattern}".`)
-    } else {
+    if (includeRegex) {
+        console.log(`No test file is found matching "${configuration.include}".`)
+    } else if (excludeRegex) {
+        console.log(`Every test file was found matching "${configuration.exclude}".`)
+    }else {
         console.log(`No test file is found.`)
     }
     process.exit(EXIT_CODES.INVALID_ARGUMENT)

--- a/client/src/cli.js
+++ b/client/src/cli.js
@@ -72,12 +72,10 @@ const testFiles = testFileNames.reduce((payload, filename) => {
 }, {})
 
 if (Object.keys(testFiles).length === 0) {
-    if (includeRegex) {
-        console.log(`No test file is found matching "${configuration.include}".`)
-    } else if (excludeRegex) {
-        console.log(`Every test file was found matching "${configuration.exclude}".`)
-    }else {
-        console.log(`No test file is found.`)
+    if (includeRegex || excludeRegex) {
+        console.log(`No test file(s) is found matching the regex supplied in your config settings.`)
+    } else {
+        console.log(`No test file(s) is found.`)
     }
     process.exit(EXIT_CODES.INVALID_ARGUMENT)
 }


### PR DESCRIPTION
QA:

# via command flag 
```
./bin/sanity-runner-macos  --test-dir ~/repos/thm-sanity/dist/ --include presentation.test.js
```
should ONLY run the presentation.test.js

```
./bin/sanity-runner-macos  --test-dir ~/repos/thm-sanity/dist/ --exclude presentation.test.js
```
should run all BUT presentation.test.js 

# via setting in config.json 

```
 ~/repos/sanity-runner/client/bin/sanity-runner-macos --config config.json
```

```
{
  "testDir": "./dist",
  "outputDir": "./output",
  "var": {
    "APP_ENV": "CA"
  },
  "lambdaFunction": "sanity-runner-dev-default",
  "exclude": "presentation.test.js"
}
```
should run all BUT presentation.test.js 

```
{
  "testDir": "./dist",
  "outputDir": "./output",
  "var": {
    "APP_ENV": "CA"
  },
  "lambdaFunction": "sanity-runner-dev-default",
  "include": "presentation.test.js"
}
```
should ONLY run the presentation.test.js
