### PR TITLE
fix: incorrect printed message for failed test count.

### DIFF
--- a/client/src/utils.js
+++ b/client/src/utils.js
@@ -154,7 +154,7 @@ const _printTestSummary = results => {
 const _formatTotal = (failures, skipped, total) => {
     const result = []
     if (failures) {
-        result.push(chalk.bold.red(`${failures} passed`))
+        result.push(chalk.bold.red(`${failures} failed`))
     }
     if (skipped) {
         result.push(chalk.bold.yellow(`${skipped} skipped`))


### PR DESCRIPTION
The print message incorrectly show `passed` for failed test counts. Fix the typo in the code.