### PR TITLE
chore: revert "Update puppeteer in group default to the latest version 🚀"

### DIFF
--- a/service/package.json
+++ b/service/package.json
@@ -33,7 +33,7 @@
     "jest-junit": "^6.3.0",
     "node-pre-gyp": "^0.12.0",
     "posix": "^4.1.2",
-    "puppeteer": "1.13.0",
+    "puppeteer": "1.11.0",
     "tar": "^4.4.4",
     "uuid": "^3.2.1",
     "waitpid2": "git://github.com/joshiggins/node-waitpid2.git#2270e88"

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -3969,10 +3969,9 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
-puppeteer@1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.13.0.tgz#187ccf5ed5caf08ed1291b262d033cc364bf88ab"
-  integrity sha512-LUXgvhjfB/P6IOUDAKxOcbCz9ISwBLL9UpKghYrcBDwrOGx1m60y0iN2M64mdAUbT4+7oZM5DTxOW7equa2fxQ==
+puppeteer@1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"


### PR DESCRIPTION
Reverts tophat/sanity-runner#79

## Description

Puppeteer may need to be left alone over Chromium version concerns. Reverting this update just in case, knowing that GreenKeeper will reopen a PR for the update later.