### PR TITLE
fix: on test failure lambda will crash cause of syntax/misspselling e…

### DIFF
--- a/client/src/run-tests.js
+++ b/client/src/run-tests.js
@@ -13,7 +13,6 @@ async function testResultPromise(
     testVariables,
     retryCount,
 ) {
-    console.log(retryCount)
     const lambda = new AWS.Lambda()
     const params = {
         FunctionName: functionName,

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -51,7 +51,7 @@ module.exports = class {
                     // force retry if test was unsuccesfull
                     // if last retry, return as normal
                     if (!res.json.success) {
-                        if (retryCount !== parseInt(ParmaxRetryCount)) { // eslint-disable-line
+                        if (retryCount !== parseInt(maxRetryCount)) { // eslint-disable-line
                             throw new Error('Test Failed!')
                         }
                     }


### PR DESCRIPTION
fix: on test failure lambda will crash cause of syntax/misspselling error. Also removing a print statement that was there for debugging. 