### PR TITLE
Log relevant test info

### DIFF
--- a/service/src/run.js
+++ b/service/src/run.js
@@ -57,7 +57,6 @@ module.exports = class {
 
     async format(results) {
         const junitContents = await fs.readFile(paths.junit(this.id), 'utf8')
-        console.log(results)
         return {
             passed: results.success,
             screenshots: results.screenshots,

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -31,13 +31,15 @@ const runJest = async function(chromePath, ...args) {
     return result
 }
 
-const logResults = function(results, testVariables, retryCount){
-    var newResult = new Object();
-    var duration = (results.testResults[0].endTime - results.testResults[0].startTime)/1000
-    var splitName = results.testResults[0].name.split("/")
-    var status = results.testResults[0].status
+const logResults = function(results, testVariables, retryCount) {
+    const newResult = new Object()
+    const duration =
+        (results.testResults[0].endTime - results.testResults[0].startTime) /
+        1000
+    const splitName = results.testResults[0].name.split('/')
+    let status = results.testResults[0].status
     if (results.numPendingTests > 0) {
-        status = "skipped"
+        status = 'skipped'
     }
 
     newResult.variables = testVariables
@@ -48,7 +50,7 @@ const logResults = function(results, testVariables, retryCount){
     newResult.startTime = results.testResults[0].startTime
     newResult.testName = splitName[splitName.length - 1]
 
-    console.log(JSON.stringify(newResult));
+    console.log(JSON.stringify(newResult))
 }
 
 module.exports = class {

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -32,7 +32,7 @@ const runJest = async function(chromePath, ...args) {
 }
 
 const logResults = function(results, testVariables, retryCount) {
-    const newResult = new Object()
+    const newResult = {}
     const duration =
         (results.testResults[0].endTime - results.testResults[0].startTime) /
         1000

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -49,7 +49,7 @@ const logResults = function(results, testVariables, retryCount) {
     newResult.endTime = results.testResults[0].endTime
     newResult.startTime = results.testResults[0].startTime
     newResult.testName = splitName[splitName.length - 1]
-    
+
     console.log(JSON.stringify(newResult))
 }
 

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -31,6 +31,26 @@ const runJest = async function(chromePath, ...args) {
     return result
 }
 
+const logResults = function(results, testVariables, retryCount){
+    var newResult = new Object();
+    var duration = (results.testResults[0].endTime - results.testResults[0].startTime)/1000
+    var splitName = results.testResults[0].name.split("/")
+    var status = results.testResults[0].status
+    if (results.numPendingTests > 0) {
+        status = "skipped"
+    }
+
+    newResult.variables = testVariables
+    newResult.retryCount = retryCount
+    newResult.duration = duration
+    newResult.status = status
+    newResult.endTime = results.testResults[0].endTime
+    newResult.startTime = results.testResults[0].startTime
+    newResult.testName = splitName[splitName.length - 1]
+
+    console.log(JSON.stringify(newResult));
+}
+
 module.exports = class {
     constructor(chromePath) {
         this.chromePath = chromePath
@@ -64,7 +84,7 @@ module.exports = class {
                     },
                 },
             )
-
+            logResults(results.json, testVariables, retryCount)
             return await run.format(results.json)
         } finally {
             await run.cleanup()

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -49,7 +49,7 @@ const logResults = function(results, testVariables, retryCount) {
     newResult.endTime = results.testResults[0].endTime
     newResult.startTime = results.testResults[0].startTime
     newResult.testName = splitName[splitName.length - 1]
-
+    
     console.log(JSON.stringify(newResult))
 }
 


### PR DESCRIPTION
the console.logs doesnt have all relevant information that can be used for tracking. Here i am generating my own json object (jest --json json blob isnt proper) and adding some extra key/values.

Added:
- retry count
- test_variables 
- duration of test. 
- sets status as skipped when test is skipped 