### PR TITLE
dynamic service name and echo out funciton name

### DIFF
--- a/service/Makefile
+++ b/service/Makefile
@@ -50,6 +50,7 @@ package: check-versions
 .PHONY: deploy
 deploy: check-versions download-serverless-chrome
 	serverless deploy --package "${BUILD_DIR}"
+	echo Function: "sanity-runner-${SERVERLESS_STAGE}-${SERVERLESS_TAG}"
 	aws s3 sync ./chrome s3://sr-${SERVERLESS_STAGE}-${SERVERLESS_TAG}/chrome
 
 # ----- Helpers -----

--- a/service/serverless.yml
+++ b/service/serverless.yml
@@ -2,7 +2,7 @@
 
 frameworkVersion: 1.34.1
 
-service: sanity
+service: ${env:SERVERLESS_FUNC, self:custom.functon_name}
 
 provider:
   name: aws


### PR DESCRIPTION
dynamic service name will stop conflicting cloudformation names in same ENV, also just echo out function name 