### PR TITLE
Update screenshot times

### DIFF
--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -23,12 +23,14 @@ const sendSlackMessage = async function(
 
         //obtain all screen shots
         const screenShotAttachments = []
+        const screenShotUrls = []
         for (const screenshotTitle of Object.keys(results.screenshots)) {
             screenShotAttachments.push({
                 title: screenshotTitle,
                 image_url: results.screenshots[screenshotTitle],
                 color: '#D40E0D',
             })
+            screenShotUrls.push(results.screenshots[screenshotTitle])
         }
 
         const appEnv = testVariables.APP_ENV || '!APP_ENV not supplied!'
@@ -39,7 +41,7 @@ const sendSlackMessage = async function(
             text: parentMessage,
         })
 
-        const screenshotMessage = 'Attached Screenshot at time of error'
+        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): [${screenShotUrls.join(", ")}]`
         await slack.chat.postMessage({
             channel: slackChannel,
             thread_ts: resParent.ts,

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -30,7 +30,7 @@ const sendSlackMessage = async function(
                 image_url: results.screenshots[screenshotTitle],
                 color: '#D40E0D',
             })
-            screenShotUrls.push(results.screenshots[screenshotTitle])
+            screenShotUrls.push(results.screenshots[screenshotTitle].split("AWSAccessKeyId")[0])
         }
 
         const appEnv = testVariables.APP_ENV || '!APP_ENV not supplied!'
@@ -41,7 +41,7 @@ const sendSlackMessage = async function(
             text: parentMessage,
         })
 
-        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): [${screenShotUrls.join(", ")}]`
+        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): ${screenShotUrls.join(", ")}]`
         await slack.chat.postMessage({
             channel: slackChannel,
             thread_ts: resParent.ts,

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -41,7 +41,7 @@ const sendSlackMessage = async function(
             text: parentMessage,
         })
 
-        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): ${screenShotUrls.join(", ")}]`
+        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): ${screenShotUrls.join(", ")}`
         await slack.chat.postMessage({
             channel: slackChannel,
             thread_ts: resParent.ts,

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -30,7 +30,9 @@ const sendSlackMessage = async function(
                 image_url: results.screenshots[screenshotTitle],
                 color: '#D40E0D',
             })
-            screenShotUrls.push(results.screenshots[screenshotTitle].split("AWSAccessKeyId")[0])
+            screenShotUrls.push(
+                results.screenshots[screenshotTitle].split('AWSAccessKeyId')[0],
+            )
         }
 
         const appEnv = testVariables.APP_ENV || '!APP_ENV not supplied!'
@@ -41,8 +43,10 @@ const sendSlackMessage = async function(
             text: parentMessage,
         })
 
-        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): ${screenShotUrls.join(", ")}`
-        
+        const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): ${screenShotUrls.join(
+            ', ',
+        )}`
+
         await slack.chat.postMessage({
             channel: slackChannel,
             thread_ts: resParent.ts,

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -42,6 +42,7 @@ const sendSlackMessage = async function(
         })
 
         const screenshotMessage = `Attached Screenshot at time of error. Screenshot s3 URL(s): ${screenShotUrls.join(", ")}`
+        
         await slack.chat.postMessage({
             channel: slackChannel,
             thread_ts: resParent.ts,

--- a/service/src/run.js
+++ b/service/src/run.js
@@ -29,7 +29,7 @@ module.exports = class {
                     '<rootDir>/src/jestSetup/screenshotReporter',
                     {
                         output: paths.results(this.id),
-                        urlExpirySeconds: 3600,
+                        urlExpirySeconds: 7200,
                         bucket: process.env.SCREENSHOT_BUCKET,
                     },
                 ],


### PR DESCRIPTION
increases timeout on presigned URL to 2 hours

and adds message with screenshot to object in s3.

ex) 

<img width="421" alt="Screen Shot 2020-02-07 at 4 32 17 PM" src="https://user-images.githubusercontent.com/42545233/74067503-6a5caf00-49c7-11ea-8508-e79719839bd9.png">
