### PR TITLE
allow optional lambda in VPC

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -45,6 +45,7 @@ make -C service install
 make -C service package
 make -C service deploy
 ```
+
 #### Client
 ```
 make -C client install

--- a/service/Makefile
+++ b/service/Makefile
@@ -49,7 +49,7 @@ package: check-versions
 
 .PHONY: deploy
 deploy: check-versions 
-	serverless deploy --package "${BUILD_DIR}"
+	serverless deploy --package "${BUILD_DIR}" --force
 	echo Function: "sanity-runner-${SERVERLESS_STAGE}-${SERVERLESS_TAG}"
 
 # ----- Helpers -----

--- a/service/serverless.env
+++ b/service/serverless.env
@@ -1,2 +1,5 @@
 export SERVERLESS_STAGE=`git branch | grep \* | cut -d ' ' -f2`
 export SERVERLESS_TAG=`aws configure get aws_access_key_id  | tr "[:upper:]" "[:lower:]"`
+export SERVERLESS_SUBNET_ID=subnet-e999fcd5
+export SERVERLESS_SG_ID=sg-0edae7cb2e985a357
+export SERVERLESS_VPC_ENABLED=true

--- a/service/serverless.env
+++ b/service/serverless.env
@@ -1,5 +1,5 @@
 export SERVERLESS_STAGE=`git branch | grep \* | cut -d ' ' -f2`
 export SERVERLESS_TAG=`aws configure get aws_access_key_id  | tr "[:upper:]" "[:lower:]"`
-export SERVERLESS_SUBNET_ID=subnet-e999fcd5
-export SERVERLESS_SG_ID=sg-0edae7cb2e985a357
-export SERVERLESS_VPC_ENABLED=true
+export SERVERLESS_SUBNET_ID=
+export SERVERLESS_SG_ID=s
+export SERVERLESS_VPC_ENABLED=

--- a/service/serverless.env
+++ b/service/serverless.env
@@ -1,5 +1,2 @@
 export SERVERLESS_STAGE=`git branch | grep \* | cut -d ' ' -f2`
 export SERVERLESS_TAG=`aws configure get aws_access_key_id  | tr "[:upper:]" "[:lower:]"`
-export SERVERLESS_SUBNET_ID=
-export SERVERLESS_SG_ID=
-export SERVERLESS_VPC_ENABLED=

--- a/service/serverless.env
+++ b/service/serverless.env
@@ -1,5 +1,5 @@
 export SERVERLESS_STAGE=`git branch | grep \* | cut -d ' ' -f2`
 export SERVERLESS_TAG=`aws configure get aws_access_key_id  | tr "[:upper:]" "[:lower:]"`
 export SERVERLESS_SUBNET_ID=
-export SERVERLESS_SG_ID=s
+export SERVERLESS_SG_ID=
 export SERVERLESS_VPC_ENABLED=

--- a/service/serverless.yml
+++ b/service/serverless.yml
@@ -9,6 +9,7 @@ provider:
   region: us-east-1
   stage: dev
   tag: default
+  vpc: ${self:custom.vpc.${env:SERVERLESS_VPC_ENABLED, 'false'}}
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -46,6 +47,12 @@ custom:
   s3_bucket: ${env:SERVERLESS_S3_BUCKET_NAME, self:custom.s3_bucket_default}
   functon_name: sanity-runner-${self:custom.stage}-${self:custom.tag}
   cf_name: sanity
+  vpc:
+    true:
+      securityGroupIds:
+        - ${env:SERVERLESS_SG_ID, "not_set"}
+      subnetIds:
+        - ${env:SERVERLESS_SUBNET_ID, "not_set"}
 
 package:
   exclude:


### PR DESCRIPTION
adds ability to optionally set lambda in a VPC. needed to do the stuff with `SERVERLESS_VPC_ENABLED` as a work around to conditionally set vpc config (as maybe you dont always want it). this also ensures serverless never crashes, and at most will ever only throw a warning that self:custom.vpc:false doesnt exist, in which case will just not put lambda in a vpc. 


--force needed to be added to serverless deploy because if a lambda already exists without VPC setting, it wont update the lambda and silently do nothing. force will update the existing lambda to be configured with VPC only with --force

added a seperate issue to doc ENVs https://github.com/tophat/sanity-runner/issues/145 will do so in another pr  