### PR TITLE
Add pagerduty support

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -48,3 +48,21 @@ Variables within the config.json must be set via camel case
   "lambdaFunction": "sanity-runner-dev-default"
 }
 ```
+
+## Supported Variables
+
+### SLACK_ALERT
+```
+sanity-runner --var SLACK_ALERT=true
+``` 
+Enables 
+
+### PAGERDUTY_ALERT
+```
+sanity-runner --var SLACK_ALERT=true
+``` 
+
+### APP_ENV
+```
+sanity-runner --var APP_ENV=true
+``` 

--- a/client/README.md
+++ b/client/README.md
@@ -55,14 +55,16 @@ Variables within the config.json must be set via camel case
 ```
 sanity-runner --var SLACK_ALERT=true
 ``` 
-Enables 
+Enables Slack alerts to trigger if configured
 
 ### PAGERDUTY_ALERT
 ```
 sanity-runner --var SLACK_ALERT=true
 ``` 
+Enables Slack alerts to trigger if configured
 
 ### APP_ENV
 ```
 sanity-runner --var APP_ENV=true
 ``` 
+Used in alerting to help signify which Environment the tests are running in. 

--- a/service/README.md
+++ b/service/README.md
@@ -40,7 +40,7 @@ ex)
 /**
  * @Owner Some Team
  * @Slack #someslack-id
- * @pgIntegrationId pagerduty-tophat
+ * @Pagerduty pagerduty-tophat
  * @Description 
  *  - It does this
  */

--- a/service/README.md
+++ b/service/README.md
@@ -21,6 +21,30 @@ We currently use [serverless](https://serverless.com/framework/docs/) to deploy 
 | `SERVERLESS_SG_ID`          | "not_set"                                             | Security Group to associate with the lambda function. Requires `VPC_ENABLED="true"` |
 | `SERVERLESS_SUBNET_ID`      | "not_set                                              | Subnet to associate with the lambda function. Requires `VPC_ENABLED="true"` |
 
+## Alerting 
+
+Sanity Runner supports two backends currently for alerting. (Pagerduty alerts and Slack messages)
+
+## Slack
+
+Requires a slack api key to be in AWS Secret Manager with the formatted name `sanity_runner/slack_api_token`. This secret should be set up with the secret/value pair of `secret:`slack_api_token and `value:` <insert slack_api_token>
+
+
+## Pagerduty
+
+Requires a Pagerduty integration key. The key should be stored in AWS Secret Manager with the formatted name `sanity_runner/pagerduty_<name of pagerduty service>`. This secret should be set up with the secret.value pair of `secret:` integration_key `value:` <integration key for intended service>. This key is optional and setup via each test by using the `@pgIntegrationId` Metadata Field.
+
+ex)
+
+```
+/**
+ * @Owner Some Team
+ * @Slack #someslack-id
+ * @pgIntegrationId pagerduty-tophat
+ * @Description 
+ *  - It does this
+ */
+```
 
 ## Quick Start
 

--- a/service/README.md
+++ b/service/README.md
@@ -25,14 +25,14 @@ We currently use [serverless](https://serverless.com/framework/docs/) to deploy 
 
 Sanity Runner supports two backends currently for alerting. (Pagerduty alerts and Slack messages)
 
-## Slack
+### Slack
 
 Requires a slack api key to be in AWS Secret Manager with the formatted name `sanity_runner/slack_api_token`. This secret should be set up with the secret/value pair of `secret:`slack_api_token and `value:` <insert slack_api_token>
 
 
-## Pagerduty
+### Pagerduty
 
-Requires a Pagerduty integration key. The key should be stored in AWS Secret Manager with the formatted name `sanity_runner/pagerduty_<name of pagerduty service>`. This secret should be set up with the secret.value pair of `secret:` integration_key `value:` <integration key for intended service>. This key is optional and setup via each test by using the `@pgIntegrationId` Metadata Field.
+Requires a [Pagerduty integration key](https://developer.pagerduty.com/docs/events-api-v2/overview/). Integration keys are generated on a service level from within Pagerduty, allowing third party tools to send events to a given service without having to give account wide API access. The key should be stored in AWS Secret Manager with the formatted name `sanity_runner/pagerduty_<name of pagerduty service>`. This secret should be set up with a secret/value pair of `secret:` integration_key `value:` <integration key for intended service>. Once the integration key is setup in aws secret manager, you can use it in any test by referencing the secret name via the metadata fields.
 
 ex)
 

--- a/service/package.json
+++ b/service/package.json
@@ -36,12 +36,12 @@
     "jest-docblock": "^24.9.0",
     "jest-environment-node": "23.4.0",
     "jest-junit": "^6.3.0",
+    "node-pagerduty": "^1.2.0",
     "node-pre-gyp": "^0.12.0",
     "posix": "^4.1.2",
     "puppeteer-core": "^2.0.0",
     "tar": "^4.4.4",
     "uuid": "^3.2.1",
     "waitpid2": "git://github.com/unbounce/node-waitpid2"
-
   }
 }

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -7,8 +7,7 @@ const sendPagerDutyAlert = async function(message, testMetaData) {
     try {
         const pd = new pdClient()
         if (!testMetaData.pgIntegrationId) {
-            console.log('No Pagerduty Integration Id supplied in test Metadata')
-            return 1
+            throw new Error('No Pagerduty Integration Id supplied in test Metadata')
         }
         const pagerDutySecret = await secretmanager.getSecretValue(
             `sanity_runner/${testMetaData.pgIntegrationId}`,
@@ -34,7 +33,6 @@ const sendPagerDutyAlert = async function(message, testMetaData) {
                 message.attachments.screenShots[screenshotTitle],
             )
         }
-        console.log(screenShotAttachments)
 
         const pl = {
             routing_key: pgIntegrationId.toString(),
@@ -71,7 +69,6 @@ const sendSlackMessage = async function(message, testMetaData) {
         const slack = new WebClient(slackToken.slack_api_token)
         const slackChannel = testMetaData.Slack
 
-        console.log(message.message)
         // Send Slack message and format into thread
         const resParent = await slack.chat.postMessage({
             channel: slackChannel,
@@ -141,7 +138,7 @@ const sendSlackMessage = async function(message, testMetaData) {
             ],
         })
     } catch (err) {
-        console.log(err)
+        console.error(err)
     }
 }
 

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -194,6 +194,11 @@ module.exports = async function(testFiles, results, testVariables) {
                 if (testVariables.SLACK_ALERT) {
                     await sendSlackMessage(message, testMetaData)
                 }
+            } else if (testVariables.hasOwnProperty('ALERT')) {
+                // Will delete eventually, but ensures no one using previous ENV will have their alerts break
+                if (testVariables.ALERT) {
+                    await sendSlackMessage(message, testMetaData)
+                }
             }
             if (testVariables.hasOwnProperty('PAGERDUTY_ALERT')) {
                 if (testVariables.PAGERDUTY_ALERT) {

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -7,7 +7,9 @@ const sendPagerDutyAlert = async function(message, testMetaData) {
     try {
         const pd = new pdClient()
         if (!testMetaData.pgIntegrationId) {
-            throw new Error('No Pagerduty Integration Id supplied in test Metadata')
+            throw new Error(
+                'No Pagerduty Integration Id supplied in test Metadata',
+            )
         }
         const pagerDutySecret = await secretmanager.getSecretValue(
             `sanity_runner/${testMetaData.pgIntegrationId}`,
@@ -160,12 +162,16 @@ const constructMessage = async function(
     for (const screenshotTitle of Object.keys(results.screenshots)) {
         screenShots.push(results.screenshots[screenshotTitle])
     }
+    console.log(testMetaData)
+    const manualSteps = testMetaData.Description
+        ? testMetaData.Description.replace(/ - /gi, '\n- ')
+        : ''
 
     const message = {
         message: mainMessage,
         errorMessage: errorMessage,
         variables: testVariables,
-        manualSteps: testMetaData.Description.replace(/ - /gi, '\n- '),
+        manualSteps: manualSteps,
         attachments: {
             screenShots: screenShots,
         },

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -6,18 +6,18 @@ const pdClient = require('node-pagerduty')
 const sendPagerDutyAlert = async function(message, testMetaData) {
     try {
         const pd = new pdClient()
-        if (!testMetaData.pgIntegrationId) {
+        if (!testMetaData.Pagerduty) {
             throw new Error(
                 'No Pagerduty Integration Id supplied in test Metadata',
             )
         }
         const pagerDutySecret = await secretmanager.getSecretValue(
-            `sanity_runner/${testMetaData.pgIntegrationId}`,
+            `sanity_runner/${testMetaData.Pagerduty}`,
         )
         if (!pagerDutySecret.hasOwnProperty('integration_key')) {
             throw new Error(
                 `Secret sanity_runner/${
-                    testMetaData.pgIntegrationId
+                    testMetaData.Pagerduty
                 } not found in AWS Secret Manager!`,
             )
         }


### PR DESCRIPTION
Adds Pagerduty alerting support.

- added a `constructMessage` function that returns a dict with all needed text for any given alert. This makes it simpler to add new alerts in the future. 

- adds pagerduty alert. configured by env PAGERDUTY_ALERT = true . 

Pagerduty service is configured via metadata similiar to slack channel. Due to integration keys being a little more secure however, the metadatra must point to the name of a secret in AWS secret manager. 

ex) created secret will have name `sanity_runner/pagerduty-tophat` with key/value  `integration_key` : `<some integration key value>`

and then the metadata must have `@pdIntegrationId pagerduty-tophat` to send alerts to said pagerduty integration 

```
/**
 * @Owner Tophat
 * @Pagerduty pagerduty-tophat
 * @Description 
 *  - confirms healthcheck api loads
 */
```

Currently only supports triggering a new alert when a test fails 

Documentation blocked on this : https://github.com/tophat/sanity-runner/pull/149/files 