### PR TITLE
Pg add dedup

### DIFF
--- a/service/Makefile
+++ b/service/Makefile
@@ -1,6 +1,7 @@
 SHELL := /bin/bash
 export PATH := $(shell yarn bin):$(PATH)
 
+
 ARTIFACTS_DIR = artifacts
 BUILD_DIR = ${ARTIFACTS_DIR}/build
 TEST_REPORTS_DIR ?= $(ARTIFACTS_DIR)/reports

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -38,6 +38,7 @@ const sendPagerDutyAlert = async function(message, testMetaData) {
 
         const pl = {
             routing_key: pgIntegrationId.toString(),
+            dedup_key: message.testName,
             event_action: 'trigger',
             images: screenShotAttachments,
             payload: {
@@ -168,6 +169,7 @@ const constructMessage = async function(
         : ''
 
     const message = {
+        testName: test,
         message: mainMessage,
         errorMessage: errorMessage,
         variables: testVariables,


### PR DESCRIPTION
adds testname as dedup key to prevent alerts on every test failure 

fixes #155 