### PR TITLE
feat: add custom user agent

### DIFF
--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -158,6 +158,9 @@ const constructMessage = async function(
     const mainMessage = `Sanity... \`${test}\` has failed in \`${appEnv}\`!`
     const errorMessage = testResults.message
 
+    //log to lambda for debugging
+    console.log(errorMessage)
+
     //Attachments
     const screenShots = []
     for (const screenshotTitle of Object.keys(results.screenshots)) {

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -11,11 +11,9 @@ beforeEach(async () => {
     global.page = await global.browser.newPage()
     try {
         const testName = getState().currentTestName
-        await global.page.setUserAgent(
-            `TophatSanityRunner/${global.lambdaContext.version}`,
-        )
+        await global.page.setUserAgent(`TophatSanityRunner`)
         await global.page.setExtraHTTPHeaders({
-            'x-sanity-runner-request-id': global.lambdaContext.awsRequestId,
+            'x-sanity-runner-request-id': global.lambdaContext.sanityRequestId,
             'x-sanity-runner-test-name': testName,
         })
     } catch (err) {

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -10,15 +10,14 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000 //eslint-disable-line
 beforeEach(async () => {
     global.page = await global.browser.newPage()
     try {
-        const testNames = Object.keys(global.globalContext.testNames).join(', ')
+        const testName = getState().currentTestName
         await global.page.setUserAgent(
-            `TophatSanityRunner/${global.globalContext.version}`,
+            `TophatSanityRunner/${global.lambdaContext.version}`,
         )
         await global.page.setExtraHTTPHeaders({
-            'x-sanity-runner-request-id': global.globalContext.awsRequestId,
-            'x-sanity-runner-test-name': testNames,
+            'x-sanity-runner-request-id': global.lambdaContext.awsRequestId,
+            'x-sanity-runner-test-name': testName,
         })
-        await global.page.setExtraHTTPHeaders()
     } catch (err) {
         console.error(err)
     }

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -9,7 +9,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000 //eslint-disable-line
 
 beforeEach(async () => {
     global.page = await global.browser.newPage()
-    await global.page.setUserAgent("TophatSanityRunner")
+    await global.page.setUserAgent('TophatSanityRunner')
 })
 
 afterEach(async () => {

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -9,7 +9,8 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000 //eslint-disable-line
 
 beforeEach(async () => {
     global.page = await global.browser.newPage()
-    await global.page.setUserAgent('TophatSanityRunner')
+    await global.page.setUserAgent(`TophatSanityRunner/${global.globalContext.version}`)
+    await global.page.setExtraHTTPHeaders({ 'x-sanity-runner-request-id': global.globalContext.awsRequestId })
 })
 
 afterEach(async () => {

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -9,8 +9,19 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000 //eslint-disable-line
 
 beforeEach(async () => {
     global.page = await global.browser.newPage()
-    await global.page.setUserAgent(`TophatSanityRunner/${global.globalContext.version}`)
-    await global.page.setExtraHTTPHeaders({ 'x-sanity-runner-request-id': global.globalContext.awsRequestId })
+    try {
+        const testNames = Object.keys(global.globalContext.testNames).join(', ')
+        await global.page.setUserAgent(
+            `TophatSanityRunner/${global.globalContext.version}`,
+        )
+        await global.page.setExtraHTTPHeaders({
+            'x-sanity-runner-request-id': global.globalContext.awsRequestId,
+            'x-sanity-runner-test-name': testNames,
+        })
+        await global.page.setExtraHTTPHeaders()
+    } catch (err) {
+        console.error(err)
+    }
 })
 
 afterEach(async () => {

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -9,6 +9,7 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 5000 //eslint-disable-line
 
 beforeEach(async () => {
     global.page = await global.browser.newPage()
+    await global.page.setUserAgent("TophatSanityRunner")
 })
 
 afterEach(async () => {

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -43,8 +43,7 @@ module.exports.handler = async function(event, context, callback) {
     const testResults = await runner.runTests(
         event.testFiles,
         event.testVariables,
-        event.retryCount,
-        context,
+        event.retryCount
     )
     callback(null, testResults)
 }

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -38,8 +38,15 @@ if (process.pid === 1) {
 }
 
 module.exports.handler = async function(event, context, callback) {
-    global.globalContext = context
-    global.globalContext.testNames = event.testFiles
+    try {
+        global.lambdaContext = {
+            version: context.version,
+            awsRequestId: context.awsRequestId,
+        }
+    } catch(e) {
+        console.log(e)
+    }
+
     console.log((await execa('find', ['/tmp'])).stdout)
     const runner = new TestRunner()
     const testResults = await runner.runTests(

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -38,12 +38,14 @@ if (process.pid === 1) {
 }
 
 module.exports.handler = async function(event, context, callback) {
+    global.globalContext = context
     console.log((await execa('find', ['/tmp'])).stdout)
     const runner = new TestRunner()
     const testResults = await runner.runTests(
         event.testFiles,
         event.testVariables,
         event.retryCount,
+        context
     )
     callback(null, testResults)
 }

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -38,15 +38,6 @@ if (process.pid === 1) {
 }
 
 module.exports.handler = async function(event, context, callback) {
-    try {
-        global.lambdaContext = {
-            version: context.version,
-            awsRequestId: context.awsRequestId,
-        }
-    } catch (e) {
-        console.log(e)
-    }
-
     console.log((await execa('find', ['/tmp'])).stdout)
     const runner = new TestRunner()
     const testResults = await runner.runTests(

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -43,7 +43,7 @@ module.exports.handler = async function(event, context, callback) {
             version: context.version,
             awsRequestId: context.awsRequestId,
         }
-    } catch(e) {
+    } catch (e) {
         console.log(e)
     }
 

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -43,7 +43,7 @@ module.exports.handler = async function(event, context, callback) {
     const testResults = await runner.runTests(
         event.testFiles,
         event.testVariables,
-        event.retryCount
+        event.retryCount,
     )
     callback(null, testResults)
 }

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -39,13 +39,14 @@ if (process.pid === 1) {
 
 module.exports.handler = async function(event, context, callback) {
     global.globalContext = context
+    global.globalContext.testNames = event.testFiles
     console.log((await execa('find', ['/tmp'])).stdout)
     const runner = new TestRunner()
     const testResults = await runner.runTests(
         event.testFiles,
         event.testVariables,
         event.retryCount,
-        context
+        context,
     )
     callback(null, testResults)
 }

--- a/service/src/run.js
+++ b/service/src/run.js
@@ -18,7 +18,7 @@ module.exports = class {
             globalSetup: '<rootDir>/src/jestSetup/puppeteer/setup.js',
             globalTeardown: '<rootDir>/src/jestSetup/puppeteer/teardown.js',
             globals: {
-                globalContext: globalContext
+                globalContext: global.globalContext,
                 SANITY_VARIABLES: this.variables || {},
                 SCREENSHOT_OUTPUT: paths.results(this.id),
             },

--- a/service/src/run.js
+++ b/service/src/run.js
@@ -18,7 +18,7 @@ module.exports = class {
             globalSetup: '<rootDir>/src/jestSetup/puppeteer/setup.js',
             globalTeardown: '<rootDir>/src/jestSetup/puppeteer/teardown.js',
             globals: {
-                globalContext: global.globalContext,
+                lambdaContext: global.lambdaContext,
                 SANITY_VARIABLES: this.variables || {},
                 SCREENSHOT_OUTPUT: paths.results(this.id),
             },

--- a/service/src/run.js
+++ b/service/src/run.js
@@ -18,6 +18,7 @@ module.exports = class {
             globalSetup: '<rootDir>/src/jestSetup/puppeteer/setup.js',
             globalTeardown: '<rootDir>/src/jestSetup/puppeteer/teardown.js',
             globals: {
+                globalContext: globalContext
                 SANITY_VARIABLES: this.variables || {},
                 SCREENSHOT_OUTPUT: paths.results(this.id),
             },

--- a/service/src/run.js
+++ b/service/src/run.js
@@ -18,7 +18,9 @@ module.exports = class {
             globalSetup: '<rootDir>/src/jestSetup/puppeteer/setup.js',
             globalTeardown: '<rootDir>/src/jestSetup/puppeteer/teardown.js',
             globals: {
-                lambdaContext: global.lambdaContext,
+                lambdaContext: {
+                    sanityRequestId: this.id,
+                },
                 SANITY_VARIABLES: this.variables || {},
                 SCREENSHOT_OUTPUT: paths.results(this.id),
             },

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -32,7 +32,7 @@ const runJest = async function(chromePath, ...args) {
     return result
 }
 
-const logResults = function(results, testVariables, retryCount) {
+const logResults = function(results, testVariables, retryCount, runId) {
     const newResult = {}
     const duration =
         (results.testResults[0].endTime - results.testResults[0].startTime) /
@@ -50,6 +50,7 @@ const logResults = function(results, testVariables, retryCount) {
     newResult.endTime = results.testResults[0].endTime
     newResult.startTime = results.testResults[0].startTime
     newResult.testName = splitName[splitName.length - 1]
+    newResult.runId = runId
 
     console.log(JSON.stringify(newResult))
 }
@@ -83,7 +84,7 @@ module.exports = class {
                     },
                 },
             )
-            logResults(results.json, testVariables, retryCount)
+            logResults(results.json, testVariables, retryCount, run.id)
             await alertOnResult(testFiles, results.json, testVariables)
             return await run.format(results.json)
         } finally {


### PR DESCRIPTION
add custom user agent to browser. 

Because the lambda is starting another jest process, it must pass the context in via jestConfig()  

![Screen Shot 2020-05-14 at 4 48 32 PM](https://user-images.githubusercontent.com/42545233/81984423-c0fb0a00-9602-11ea-99c5-b82ede9c5af7.png)

tested and confirm it gets set in our datadog apm traces 


https://app.datadoghq.com/logs?cols=host%2Cservice%2C%40lambda.request_id&event&from_ts=1589912013672&index=&live=true&messageDisplay=inline&query=%40request.headers.user-agent%3A%22TophatSanityRunner%2Fundefined%22&stream_sort=desc&to_ts=1589915613672 

can see here 


ALSO: snuck in logging errorMessages from tests. we currently dont see this in lambda logs, and would be usefull 