### PR TITLE
Resolve pagerduty

### DIFF
--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -246,15 +246,14 @@ module.exports = async function(testFiles, results, testVariables) {
                 }
             }
         }
-    }
-    else if (results.numFailedTests == 0) {
+    } else if (results.numFailedTests === 0) {
         if (testVariables.hasOwnProperty('PAGERDUTY_ALERT')) {
             for (const testFile of Object.keys(testFiles)) {
                 const testContents = testFiles[testFile]
                 const testMetaData = parse(testContents)
                 if (testVariables.PAGERDUTY_ALERT) {
                     await resolvePagerDutyAlert(testFile, testMetaData)
-                } 
+                }
             }
         }
     }

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -3,6 +3,37 @@ const { WebClient } = require('@slack/web-api')
 const secretmanager = require('./secrets')
 const pdClient = require('node-pagerduty')
 
+const resolvePagerDutyAlert = async function(testFile, testMetaData) {
+    try {
+        const pd = new pdClient()
+        if (!testMetaData.Pagerduty) {
+            throw new Error(
+                'No Pagerduty Integration Id supplied in test Metadata',
+            )
+        }
+        const pagerDutySecret = await secretmanager.getSecretValue(
+            `sanity_runner/${testMetaData.Pagerduty}`,
+        )
+        if (!pagerDutySecret.hasOwnProperty('integration_key')) {
+            throw new Error(
+                `Secret sanity_runner/${
+                    testMetaData.Pagerduty
+                } not found in AWS Secret Manager!`,
+            )
+        }
+        const pgIntegrationId = pagerDutySecret.integration_key
+
+        const pl = {
+            routing_key: pgIntegrationId.toString(),
+            dedup_key: testFile,
+            event_action: 'resolve',
+        }
+        await pd.events.sendEvent(pl)
+    } catch (err) {
+        console.error(err)
+    }
+}
+
 const sendPagerDutyAlert = async function(message, testMetaData) {
     try {
         const pd = new pdClient()
@@ -213,6 +244,17 @@ module.exports = async function(testFiles, results, testVariables) {
                 if (testVariables.PAGERDUTY_ALERT) {
                     await sendPagerDutyAlert(message, testMetaData)
                 }
+            }
+        }
+    }
+    else if (results.numFailedTests == 0) {
+        if (testVariables.hasOwnProperty('PAGERDUTY_ALERT')) {
+            for (const testFile of Object.keys(testFiles)) {
+                const testContents = testFiles[testFile]
+                const testMetaData = parse(testContents)
+                if (testVariables.PAGERDUTY_ALERT) {
+                    await resolvePagerDutyAlert(testFile, testMetaData)
+                } 
             }
         }
     }


### PR DESCRIPTION
Sends resolve event to PG on tests configured with PG whenever they pass.

This adds one API call everytime these tests are ran, which shouldnt be an issue. 1 event every 10 min shouldnt be throttled. Can add checking if event is triggered/awknowledged first before sending resolve event if we want. 

This will auto resolve a PG alarm if it was previously failing then started working again 