### PR TITLE
close browser after all

### DIFF
--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -35,5 +35,9 @@ afterEach(async () => {
         fullPage: true,
         path: screenshotPath,
     })
+    await global.page.close()
+})
+
+afterAll(async () => {
     await global.browser.close()
 })


### PR DESCRIPTION
Resolves #170

Changes some jest-puppeteer functionality:
    - Closes Browser after all tests are ran.
    - Closes Page after each test 


QA: 
- [x] two(or more) tests in same file can pass
- [x] Output displays correctly when one test fails and one (or more) tests pass 
- [x] Screen shots are taken correctly and passed to the client accordingly  
- [ ] Cookies/Cache of one test dont affect another 
- [ ] Alerting Works for when one test fails and one passes in same file 
- [ ] Timeout due to running to many tests prints correct error statements 