### PR TITLE
add test suite level execution id

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
         "lodash": "^4.17.11",
         "pkg": "^4.3.3",
         "promise-retry": "^1.1.1",
+        "unique-string": "^2.0.0",
         "xml2js": "^0.4.19"
     },
     "bin": {

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -437,6 +437,11 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
+crypto-random-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
+  integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -540,10 +545,10 @@ escodegen@1.10.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-eslint-config-prettier@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-5.0.0.tgz#f7a94b2b8ae7cbf25842c36fa96c6d32cd0a697c"
-  integrity sha512-c17Aqiz5e8LEqoc/QPmYnaxQFAHTx2KlCZBPxXXjEMmNchOLnV/7j0HoPZuC+rL/tDC9bazUYOKJW9bOhftI/w==
+eslint-config-prettier@^6.1.0:
+  version "6.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.12.0.tgz#9eb2bccff727db1c52104f0b49e87ea46605a0d2"
+  integrity sha512-9jWPlFlgNwRUYVoujvWTQ1aMO8o6648r+K7qU7K5Jmkbyqav1fuEZC0COYpGBxyiAJb65Ra9hrmFx19xRGwXWw==
   dependencies:
     get-stdin "^6.0.0"
 
@@ -2193,6 +2198,13 @@ union-value@^1.0.0:
     get-value "^2.0.6"
     is-extendable "^0.1.1"
     set-value "^0.4.3"
+
+unique-string@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-2.0.0.tgz#39c6451f81afb2749de2b233e3f7c5e8843bd89d"
+  integrity sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+  dependencies:
+    crypto-random-string "^2.0.0"
 
 unique-temp-dir@1.0.0:
   version "1.0.0"

--- a/service/src/lambdaHandler.js
+++ b/service/src/lambdaHandler.js
@@ -44,6 +44,7 @@ module.exports.handler = async function(event, context, callback) {
         event.testFiles,
         event.testVariables,
         event.retryCount,
+        event.executionId,
     )
     callback(null, testResults)
 }

--- a/service/src/testRunner.js
+++ b/service/src/testRunner.js
@@ -32,7 +32,13 @@ const runJest = async function(chromePath, ...args) {
     return result
 }
 
-const logResults = function(results, testVariables, retryCount, runId) {
+const logResults = function(
+    results,
+    testVariables,
+    retryCount,
+    runId,
+    executionId,
+) {
     const newResult = {}
     const duration =
         (results.testResults[0].endTime - results.testResults[0].startTime) /
@@ -51,12 +57,13 @@ const logResults = function(results, testVariables, retryCount, runId) {
     newResult.startTime = results.testResults[0].startTime
     newResult.testName = splitName[splitName.length - 1]
     newResult.runId = runId
+    newResult.executionId = executionId
 
     console.log(JSON.stringify(newResult))
 }
 
 module.exports = class {
-    async runTests(testFiles, testVariables, maxRetryCount) {
+    async runTests(testFiles, testVariables, maxRetryCount, executionId) {
         let retryCount = 0
         const run = new Run(testVariables)
         try {
@@ -85,7 +92,13 @@ module.exports = class {
                     },
                 },
             )
-            logResults(results.json, testVariables, retryCount, run.id)
+            logResults(
+                results.json,
+                testVariables,
+                retryCount,
+                run.id,
+                executionId,
+            )
             await alertOnResult(testFiles, results.json, testVariables)
             return await run.format(results.json)
         } finally {


### PR DESCRIPTION
adds an execution id that gets added to every test ran in a suite. This allows for easy tracking of an entire suite that was ran. Can group these in datadog then.

QA:
log event example 
```
{
    "variables": {
        "APP_ENV": "US",
    },
    "retryCount": 0,
    "duration": 1.694,
    "status": "passed",
    "endTime": 1601499463066,
    "startTime": 1601499461372,
    "testName": "healthcheck.test.js",
    "runId": "d14beeec-f9a0-412c-a682-231552e0d434",
    "executionId": "775b09b1d122db4757bd97a24d198e8a"
}

```

also ran it with a client that wasnt sending an executionId and got no error. This means it should be backwards compatable with older versions of the client. (incase an old client is sending to a new service) 
```
{
    "variables": {
        "APP_ENV": "US",
        "EX_ID": "359f47e8c14aa058104a46df8e128193"
    },
    "retryCount": 0,
    "duration": 1.329,
    "status": "passed",
    "endTime": 1601499575290,
    "startTime": 1601499573961,
    "testName": "healthcheck.test.js",
    "runId": "122dd250-eb14-4977-8e81-40526cce30f6"
}
```