### PR TITLE
feat: Add Runbook pragma

### DIFF
--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -162,6 +162,19 @@ const sendSlackMessage = async function(message, testMetaData) {
             ],
         })
 
+        if (message.runBook) {
+            await slack.chat.postMessage({
+                channel: slackChannel,
+                thread_ts: resParent.ts,
+                attachments: [
+                    {
+                        title: 'Runbook to follow',
+                        text: message.runBook,
+                    },
+                ],
+            })
+        }
+
         // jest-docblock does not support multiline strings and seperates them with spaces.
         // We enforce a standard of "-" surronded by spaces as the standard practice for making
         // a new line in the description of a test.
@@ -206,12 +219,15 @@ const constructMessage = async function(
         ? testMetaData.Description.replace(/ - /gi, '\n- ')
         : ''
 
+    const runBook = testMetaData.Runbook ? testMetaData.Runbook : ''
+
     const message = {
         testName: test,
         message: mainMessage,
         errorMessage: errorMessage,
         variables: testVariables,
         manualSteps: manualSteps,
+        runBook: runBook,
         attachments: {
             screenShots: screenShots,
         },


### PR DESCRIPTION
Adds run book pragma that lets you link a Runbook URL that gets added to an alert. 

ex)

```
 * @Owner Experience: Assessment
 * @Slack #bot-proving-ground
 * @Runbook https://tophat.atlassian.net/wiki/spaces/TOP/pages/885358599/Sanity+Slack+Failure+-+Runbook
```

<img width="308" alt="Screen Shot 2020-10-02 at 2 47 09 PM" src="https://user-images.githubusercontent.com/42545233/94958815-29695b80-04be-11eb-9714-2121ce4d72d1.png">
