### PR TITLE
fix: avoid throwing an error on missing Pagerduty integration

### DIFF
--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -7,9 +7,10 @@ const resolvePagerDutyAlert = async function(testFile, testMetaData) {
     try {
         const pd = new pdClient()
         if (!testMetaData.Pagerduty) {
-            throw new Error(
-                'No Pagerduty Integration Id supplied in test Metadata',
+            console.log(
+                'Unable to send Pagerduty alert: no Pagerduty Integration Id supplied in test Metadata',
             )
+            return
         }
         const pagerDutySecret = await secretmanager.getSecretValue(
             `sanity_runner/${testMetaData.Pagerduty}`,
@@ -38,9 +39,10 @@ const sendPagerDutyAlert = async function(message, testMetaData) {
     try {
         const pd = new pdClient()
         if (!testMetaData.Pagerduty) {
-            throw new Error(
-                'No Pagerduty Integration Id supplied in test Metadata',
+            console.log(
+                'Unable to send Pagerduty alert: no Pagerduty Integration Id supplied in test Metadata',
             )
+            return
         }
         const pagerDutySecret = await secretmanager.getSecretValue(
             `sanity_runner/${testMetaData.Pagerduty}`,


### PR DESCRIPTION
Previously, when Pagerduty alerting was enabled (i.e. when `PAGERDUTY_ALERT` test variable was set) but a test didn't have `Pagerduty` set in metadata, the sanity runner would throw an error. This should not be an error condition.

### DevQA

This branch has been deployed to the following lambda: `sanity-runner-no-error-on-m-asiaqefsjrmxuhciil4c`.
You can test these changes by running a failing test using the lambda, with the `PAGERDUTY_ALERT` test variable set:
1. Force a sanity test to fail by adding `return Promise.reject()` to the end of the test.
2. Make the following change to the sanities config file:
```
diff --git a/config.json b/config.json
index aece119..3682751 100644
--- a/config.json
+++ b/config.json
@@ -2,8 +2,9 @@
   "testDir": "./dist",
   "outputDir": "./output",
   "var": {
-    "APP_ENV": "US"
+    "APP_ENV": "US",
+    "PAGERDUTY_ALERT": "true"
   },
-  "lambdaFunction": "sanity-runner-dev-default",
+  "lambdaFunction": "sanity-runner-no-error-on-m-asiaqefsjrmxuhciil4c",
   "retryCount": "3"
 }
```
3. Run the failing test:
```
$ AWS_REGION=us-east-1 AWS_PROFILE=tophat-dev make run-test test=<TEST NAME>
```

You should see the following INFO log, but no error:
```
Unable to send Pagerduty alert: no Pagerduty Integration Id supplied in test Metadata
```