### PR TITLE
feat: add docker container image for aws lambda container support

### DIFF
--- a/.github/actions/docker-push/actions.yml
+++ b/.github/actions/docker-push/actions.yml
@@ -7,19 +7,16 @@ inputs:
   project:
     description: name of sub project (client or service)
     required: true
-  username:
-    description: Username for docker registry
-    required: true
-  password:
-    description: Password for docker registry
-    required: true
+
 steps:
   - name: Load docker archive
     run: docker load < ${{ inputs.archivePath }}
-  - name: Log in to Docker Hub
+  -
+    name: Login to GHCR
     uses: docker/login-action@v1
     with:
-      username: ${{ inputs.username }}
-      password: ${{ inputs.password }}
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
   - name: Publish the image to Docker Hub
     run: make -C ${{ inputs.project }} publish-docker

--- a/.github/actions/docker-push/actions.yml
+++ b/.github/actions/docker-push/actions.yml
@@ -1,0 +1,25 @@
+name: docker-push
+description: Push sanity runner service container image to Docker Hub
+inputs:
+  archivePath:
+    description: Path to the saved docker image archive
+    required: true
+  project:
+    description: name of sub project (client or service)
+    required: true
+  username:
+    description: Username for docker registry
+    required: true
+  password:
+    description: Password for docker registry
+    required: true
+steps:
+  - name: Load docker archive
+    run: docker load < ${{ inputs.archivePath }}
+  - name: Log in to Docker Hub
+    uses: docker/login-action@v1
+    with:
+      username: ${{ inputs.username }}
+      password: ${{ inputs.password }}
+  - name: Publish the image to Docker Hub
+    run: make -C ${{ inputs.project }} publish-docker

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,7 +79,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: service-artifacts
-          path: service/artifacts/build docker-cache
+          path: |
+            service/artifacts/build
+            docker-cache
   release-dry-run:
     if: (github.ref != 'refs/heads/master') && (!contains(github.event.head_commit.message, 'skip ci'))
     needs: [service, client]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -74,7 +74,7 @@ jobs:
       - name: cache docker
         run: |
           mkdir -p docker-cache
-          docker save -o docker-cache/sanity-docker-service.tar tophat/sanity-runner-service:latest
+          docker save -o docker-cache/sanity-service-docker.tar tophat/sanity-runner-service:latest
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -158,6 +158,13 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           GH_TOKEN: ${{ secrets.TOPHAT_BOT_GH_TOKEN }}
+      - name: Publish service image
+        uses: ./github/actions/docker-push
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          project: service
+          archivePath: service/bin/docker-cache/sanity-docker.tar
   website:
     name: Deploy website
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: service-artifacts
-          path: service/artifacts/build
+          path: service/artifacts/build docker-cache
   release-dry-run:
     if: (github.ref != 'refs/heads/master') && (!contains(github.event.head_commit.message, 'skip ci'))
     needs: [service, client]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,7 +37,7 @@ jobs:
       - name: cache docker
         run: |
           mkdir -p docker-cache
-          docker save -o docker-cache/sanity-docker.tar tophat/sanity-runner:latest
+          docker save -o docker-cache/sanity-docker.tar ghcr.io/sanity-runner-client:latest
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -74,7 +74,7 @@ jobs:
       - name: cache docker
         run: |
           mkdir -p docker-cache
-          docker save -o docker-cache/sanity-service-docker.tar tophat/sanity-runner-service:latest
+          docker save -o docker-cache/sanity-service-docker.tar ghcr.io/sanity-runner-service:latest
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -146,25 +146,22 @@ jobs:
         run: make install
       - name: package artifacts
         run: make create-release-package
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: run release dry run
         run: |
           make deploy-release-dry
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          GH_TOKEN: ${{ secrets.TOPHAT_BOT_GH_TOKEN }}
       - name: run release
         run: |
           make deploy-release
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          GH_TOKEN: ${{ secrets.TOPHAT_BOT_GH_TOKEN }}
       - name: Publish service image
         uses: ./github/actions/docker-push
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
           project: service
           archivePath: service/bin/docker-cache/sanity-docker.tar
   website:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,6 +69,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           project: service
+      - name: build docker for service
+        run: make -C service build-docker
+      - name: cache docker
+        run: |
+          mkdir -p docker-cache
+          docker save -o docker-cache/sanity-docker-service.tar tophat/sanity-runner-service:latest
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ example/repo/yarn.lock
 example/repo/node_modules/
 example/repo/output/
 
+# client
+client/bin
+
 serverless_chromium.zip
 headless-chromium
 release-archive

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,11 +1,11 @@
 module.exports = {
     'verifyConditions': {
         'path': 'semantic-release-docker',
-        'registryUrl': 'docker.io'
+        'registryUrl': 'ghcr.io'
     },
     'publish': {
         'path': 'semantic-release-docker',
-        'name': 'tophat/sanity-runner'
+        'name': 'ghcr.io/sanity-runner-client'
     },
     'plugins': [
         '@semantic-release/commit-analyzer',
@@ -19,7 +19,7 @@ module.exports = {
             ]
         }],
         ['semantic-release-docker', {
-            'name': 'tophat/sanity-runner'
+            'name': 'ghcr.io/sanity-runner-client'
         }]
     ]
 }

--- a/client/Makefile
+++ b/client/Makefile
@@ -21,7 +21,7 @@ install: check-versions
 .PHONY: build-docker
 build-docker:
 	@echo "Building Docker Container"
-	docker build . -t tophat/sanity-runner
+	docker build . -t ghcr.io/sanity-runner-client
 
 .PHONY: package
 package:

--- a/client/src/cli.js
+++ b/client/src/cli.js
@@ -25,6 +25,7 @@ const DEFAULT_RETRY_COUNT = 0
 
 program
     .version(require('../package.json').version)
+    .name('sanity-runner')
     .arguments('[options] [testPathPattern]')
     .option(
         '--config <path>',

--- a/service/Dockerfile
+++ b/service/Dockerfile
@@ -1,0 +1,18 @@
+# Use aws lambda base image
+FROM public.ecr.aws/lambda/nodejs:10
+
+# Install system dependencies
+RUN yum install -y git make gcc gcc-c++
+
+# Install yarn
+RUN npm install -g yarn
+
+# Copy source files
+COPY package.json ./package.json
+COPY yarn.lock ./yarn.lock
+COPY src ./src
+
+# Install package dependencies
+RUN yarn install
+
+CMD ["src/lambdaHandler.handler"]

--- a/service/Makefile
+++ b/service/Makefile
@@ -76,3 +76,11 @@ lint-fix:
 build-docker:
 	@echo "Building Docker Container"
 	docker build . -t tophat/sanity-runner-service
+
+.PHONY: publish-docker
+publish-docker:
+	@echo "Publishing Docker Image"
+	VERSION=$(cat package.json | jq -r '.version')
+	docker tag tophat/sanity-runner-service:latest tophat/sanity-runner-service:${VERSION}
+	docker push tophat/sanity-runner-service@latest
+	docker push tophat/sanity-runner-service@${VERSION}

--- a/service/Makefile
+++ b/service/Makefile
@@ -49,7 +49,7 @@ package: check-versions
 	serverless package --package "${BUILD_DIR}"
 
 .PHONY: deploy
-deploy: check-versions 
+deploy: check-versions
 	serverless deploy --package "${BUILD_DIR}" --force
 	echo Function: "sanity-runner-${SERVERLESS_STAGE}-${SERVERLESS_TAG}"
 
@@ -71,3 +71,8 @@ lint:
 .PHONY: lint-fix
 lint-fix:
 	$(ESLINT) --fix .
+
+.PHONY: build-docker
+build-docker:
+	@echo "Building Docker Container"
+	docker build . -t tophat/sanity-runner-service

--- a/service/Makefile
+++ b/service/Makefile
@@ -75,12 +75,12 @@ lint-fix:
 .PHONY: build-docker
 build-docker:
 	@echo "Building Docker Container"
-	docker build . -t tophat/sanity-runner-service
+	docker build . -t ghcr.io/sanity-runner-service
 
 .PHONY: publish-docker
 publish-docker:
 	@echo "Publishing Docker Image"
 	VERSION=$(cat package.json | jq -r '.version')
-	docker tag tophat/sanity-runner-service:latest tophat/sanity-runner-service:${VERSION}
-	docker push tophat/sanity-runner-service@latest
-	docker push tophat/sanity-runner-service@${VERSION}
+	docker tag ghcr.io/sanity-runner-service:latest ghcr.io/sanity-runner-service:${VERSION}
+	docker push ghcr.io/sanity-runner-service@latest
+	docker push ghcr.io/sanity-runner-service@${VERSION}

--- a/service/package.json
+++ b/service/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "sanity",
-  "version": "0.0.1",
+  "name": "sanity-runner-service",
+  "version": "2.0.0",
   "description": "Distributed Sanity Test Suite Runner",
   "main": "service/handler.js",
   "scripts": {

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -35,9 +35,5 @@ afterEach(async () => {
         fullPage: true,
         path: screenshotPath,
     })
-    await global.page.close()
-})
-
-afterAll(async () => {
     await global.browser.close()
 })

--- a/service/src/jestSetup/e2eFrameworkSetup.js
+++ b/service/src/jestSetup/e2eFrameworkSetup.js
@@ -35,5 +35,9 @@ afterEach(async () => {
         fullPage: true,
         path: screenshotPath,
     })
+    await global.page.close()
+})
+
+afterAll(async () => {
     await global.browser.close()
 })


### PR DESCRIPTION
## Summary
- Create a new Dockerfile for running the service in AWS Lambda container. The image will be published to Docker Hub and make it easy to extend.
- The major `version` of service will now match `puppeteer-core`. This is to make it clearer which puppeteer (and chrome) version that the sanity runner container is supporting.