### PR TITLE
Support Slack multiple channel + slack threads  

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -90,7 +90,15 @@ Run Client against folder with written sanity tests
 
 ### Local
 
-TBD
+You can use the --local and --localPort flags to point the sanity-runner-client to a local container running the service. This can make local debugging of the sanity-runner-service a lot easier.
+
+Launch service container
+
+docker run -p 9000:8080 ghcr.io/tophat/sanity-runner-service:latest
+In a seperate terminal...
+
+sanity-runner-client --test-dir example/repo/sanities/ --local --output-dir output --include google-fail-example
+NOTE: local usage of the sanity-runner-client requires only a SINGLE test being passed in. Either use a test suite with one test, or use the --include to regex match on a single test.
 
 ## Reccomend Project Setups 
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ release-archive
 .terraform.lock.hcl
 
 .yarn/
+
+output

--- a/client/README.md
+++ b/client/README.md
@@ -7,7 +7,6 @@ The sanity-runner client takes a suite of test files and distributes them to a d
 sanity-runner --test-dir path/to/tests --output-dir path/to/output/dir --lambda-function lambdafunction-name
 ```
 
-
 ## Supported Arguments
 
 ```
@@ -23,8 +22,11 @@ $sanity-runner --help
     --include <regexForTestFiles>     Have the client ONLY run test files matching the supplied regex
     --exclude <regexForTestFiles>     Have the client ignore NOT run test files matching the supplied regex
     --lambda-function [functionName]  The AWS Lambda function name. Default to sanity-runner-dev-default if omitted.
+    --localPort [localPort]           Send tests to container instead of lambda. Used in conjuction with --local Default to 9000 if omitted.
+    --local                           Enables local mode for the sanity-runner-client. Will send tests to local container instead of lambda. Used in conjuction with --containerName
     --output-dir <directory>          Test results output directory.
     --var [VAR=VALUE]                 Custom variables passed to all jest tests. (default: [object Object])
+    --retry-count <retryCount>        Specify number of retries a test will perform if an error occurs (default 0)
     -h, --help                        output usage information
 ```
 
@@ -57,8 +59,6 @@ sanity-runner --var SLACK_ALERT=true
 ``` 
 Enables Slack alerts to trigger if configured
 
-
-
 ### PAGERDUTY_ALERT
 ```
 sanity-runner --var SLACK_ALERT=true
@@ -72,3 +72,16 @@ sanity-runner --var APP_ENV=true
 Used in alerting to help signify which Environment the tests are running in. 
 
 
+## Local Usage
+You can use the `--local` and `--localPort` flags to point the sanity-runner-client to a local container running the service. This can make local debugging of the sanity-runner-service a lot easier.
+
+Launch service container 
+```
+docker run -p 9000:8080 ghcr.io/tophat/sanity-runner-service:latest
+```
+In a seperate terminal...
+
+```
+sanity-runner-client --test-dir example/repo/sanities/ --local --output-dir output --include google-fail-example
+```
+NOTE: local usage of the sanity-runner-client requires only a SINGLE test being passed in. Either use a test suite with one test, or use the `--include` to regex match on a single test.

--- a/client/src/cli.js
+++ b/client/src/cli.js
@@ -20,10 +20,10 @@ const CONFIG_OPTIONS = [
     'exclude',
     'retryCount',
     'local',
-    'containerName',
+    'localPort',
 ]
 const DEFAULT_FUNCTION_NAME = 'sanity-runner-dev-default'
-const DEFAULT_CONTAINER_NAME = 'ghcr.io/tophat/sanity-runner-client:latest'
+const DEFAULT_LOCAL_PORT = '9000'
 const DEFAULT_TEST_DIR = '.'
 const DEFAULT_OUTPUT_DIR = './output'
 const DEFAULT_RETRY_COUNT = 0
@@ -53,7 +53,7 @@ program
     )
     .option(
         '--localPort [localPort]',
-        `Send tests to container instead of lambda. Used in conjuction with --local Default to ${DEFAULT_CONTAINER_NAME} if omitted.`,
+        `Send tests to container instead of lambda. Used in conjuction with --local Default to ${DEFAULT_LOCAL_PORT} if omitted.`,
     )
     .option(
         '--local',
@@ -130,7 +130,7 @@ const functionName = configuration.lambdaFunction || DEFAULT_FUNCTION_NAME
 const outputDir = path.resolve(configuration.outputDir || DEFAULT_OUTPUT_DIR)
 const testVariables = configuration.var
 const retryCount = configuration.retryCount || DEFAULT_RETRY_COUNT
-const containerName = configuration.containerName || DEFAULT_CONTAINER_NAME
+const localPort = configuration.localPort || DEFAULT_LOCAL_PORT
 const enableLocal = configuration.local || false
 
 runTests(
@@ -139,8 +139,8 @@ runTests(
     outputDir,
     testVariables,
     retryCount,
-    containerName,
     enableLocal,
+    localPort,
 )
     .then(function(testsPassed) {
         console.log('All test suites ran.')

--- a/client/src/cli.js
+++ b/client/src/cli.js
@@ -17,8 +17,11 @@ const CONFIG_OPTIONS = [
     'var',
     'exclude',
     'retryCount',
+    'local',
+    'containerName'
 ]
 const DEFAULT_FUNCTION_NAME = 'sanity-runner-dev-default'
+const DEFAULT_CONTAINER_NAME = 'ghcr.io/tophat/sanity-runner-client:latest'
 const DEFAULT_TEST_DIR = '.'
 const DEFAULT_OUTPUT_DIR = './output'
 const DEFAULT_RETRY_COUNT = 0
@@ -45,6 +48,14 @@ program
     .option(
         '--lambda-function [functionName]',
         `The AWS Lambda function name. Default to ${DEFAULT_FUNCTION_NAME} if omitted.`,
+    )
+    .option(
+        '--container-name [containerName]',
+        `Send tests to container instead of lambda. Used in conjuction with --local Default to ${DEFAULT_CONTAINER_NAME} if omitted.`,
+    )
+    .option(
+        '--local',
+        'Enables local mode for the sanity-runner-client. Will send tests to local container instead of lambda. Used in conjuction with --containerName' 
     )
     .option('--output-dir <directory>', 'Test results output directory.')
     .option(
@@ -109,8 +120,13 @@ const functionName = configuration.lambdaFunction || DEFAULT_FUNCTION_NAME
 const outputDir = path.resolve(configuration.outputDir || DEFAULT_OUTPUT_DIR)
 const testVariables = configuration.var
 const retryCount = configuration.retryCount || DEFAULT_RETRY_COUNT
+const containerName = configuration.containerName || DEFAULT_CONTAINER_NAME
+const enableLocal = configuration.local || false
+console.log(configuration.local)
+console.log(configuration.enableLocal)
 
-runTests(functionName, testFiles, outputDir, testVariables, retryCount)
+
+runTests(functionName, testFiles, outputDir, testVariables, retryCount, containerName, enableLocal)
     .then(function(testsPassed) {
         console.log('All test suites ran.')
         process.exit(testsPassed ? EXIT_CODES : EXIT_CODES.TEST_FAILED)

--- a/client/src/exit-codes.js
+++ b/client/src/exit-codes.js
@@ -3,5 +3,6 @@ const EXIT_CODES = {
     FATAL_ERROR: 1,
     INVALID_ARGUMENT: 9,
     TEST_FAILED: 2,
+    TOO_MANY_TESTS: 10,
 }
 module.exports = EXIT_CODES

--- a/client/src/run-tests.js
+++ b/client/src/run-tests.js
@@ -188,7 +188,7 @@ async function runTests(
 function _archiveTestResults(outputDir, testResults) {
     Object.entries(testResults).forEach(([key, value]) => {
         const outputPath = path.join(outputDir, key)
-        fs.outputFileSync(outputPath, JSON.stringify(value), 'utf8')
+        fs.outputFileSync(outputPath, value, 'utf8')
     })
 }
 

--- a/client/src/run-tests.js
+++ b/client/src/run-tests.js
@@ -17,13 +17,19 @@ async function testResultPromise(
     testFiles,
     testVariables,
     retryCount,
-    containerName,
     enableLocal,
+    localPort,
 ) {
     let results = {}
     const testName = getTestName(testFiles)
     if (enableLocal) {
-        await localInvoke(testFiles, testVariables, retryCount, executionId)
+        await localInvoke(
+            testFiles,
+            testVariables,
+            retryCount,
+            executionId,
+            localPort,
+        )
             .then(response => {
                 console.log(response.data)
                 results = JSON.parse(response.data)
@@ -86,9 +92,15 @@ function reduceTestResults(accumulated, current) {
     }
 }
 
-async function localInvoke(testFiles, testVariables, retryCount, executionId) {
+async function localInvoke(
+    testFiles,
+    testVariables,
+    retryCount,
+    executionId,
+    localPort,
+) {
     return axios.post(
-        'http://localhost:9000/2015-03-31/functions/function/invocations',
+        `http://localhost:${localPort}/2015-03-31/functions/function/invocations`,
         JSON.stringify({
             testFiles,
             testVariables,
@@ -140,8 +152,8 @@ async function runTests(
     outputDir,
     testVariables,
     retryCount,
-    containerName,
     enableLocal,
+    localPort,
 ) {
     const executionId = uniqueString()
 
@@ -152,8 +164,8 @@ async function runTests(
             { [entry[0]]: entry[1] },
             testVariables,
             retryCount,
-            containerName,
             enableLocal,
+            localPort,
         ),
     )
     return Promise.all(promises).then(

--- a/client/src/run-tests.js
+++ b/client/src/run-tests.js
@@ -31,8 +31,7 @@ async function testResultPromise(
             localPort,
         )
             .then(response => {
-                console.log(response.data)
-                results = JSON.parse(response.data)
+                results = response.data
             })
             .catch(e => {
                 results.testResults = {}

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -213,11 +213,8 @@ const constructMessage = async function(
 
     //Attachments
     const screenShots = []
-    console.log("HERERERE")
-    console.log(results.screenshots)
-    if(results.screenshots){
+    if (results.screenshots) {
         for (const screenshotTitle of Object.keys(results.screenshots)) {
-            console.log("asdasd")
             screenShots.push(results.screenshots[screenshotTitle])
         }
     }

--- a/service/src/alertOnResult.js
+++ b/service/src/alertOnResult.js
@@ -213,8 +213,13 @@ const constructMessage = async function(
 
     //Attachments
     const screenShots = []
-    for (const screenshotTitle of Object.keys(results.screenshots)) {
-        screenShots.push(results.screenshots[screenshotTitle])
+    console.log("HERERERE")
+    console.log(results.screenshots)
+    if(results.screenshots){
+        for (const screenshotTitle of Object.keys(results.screenshots)) {
+            console.log("asdasd")
+            screenShots.push(results.screenshots[screenshotTitle])
+        }
     }
     console.log(testMetaData)
     const manualSteps = testMetaData.Description


### PR DESCRIPTION
Adds support for multiple slack channels to be alerted on.

### Multi-channel support
```
 * @Slack #bot-proving-ground, #another-channel #a-third-channel
```

multiple channels can be configured now using commas or space as seperators.

Additional channels can be passed in as well via 
```
--var SLACK_CHANNELS=#an-example-channel
```
### Thread support
threads can be supported by using the format `<SLACK_CHANNEL>:<THREAD_TS>`

```
--var SLACK_CHANNELS=#an-example-channel:123123123.12312
```
