### PR TITLE
only alert if numpassed is 0

### DIFF
--- a/service/src/alerts/index.ts
+++ b/service/src/alerts/index.ts
@@ -19,7 +19,7 @@ export async function alertOnResult({
     testVariables: Partial<Record<string, string>>
     runId: string
 }) {
-    const isFailure = results.numFailedTests > 0 && results.numPassedTests == 0
+    const isFailure = results.numFailedTests > 0 && results.numPassedTests === 0
 
     if (isFailure) {
         for (const [testFile, testContents] of Object.entries(testFiles)) {

--- a/service/src/alerts/index.ts
+++ b/service/src/alerts/index.ts
@@ -19,7 +19,7 @@ export async function alertOnResult({
     testVariables: Partial<Record<string, string>>
     runId: string
 }) {
-    const isFailure = results.numFailedTests > 0
+    const isFailure = results.numFailedTests > 0 && results.numPassedTests == 0
 
     if (isFailure) {
         for (const [testFile, testContents] of Object.entries(testFiles)) {


### PR DESCRIPTION
Currently if a test fails, retries, then passes, it will still alert because num failed will be 1, and num passed will also be 1.

Here we are saying lets only alert if there are no passing tests 

ex results confirm this value exists
```
{"numFailedTestSuites":0,"numFailedTests":0,"numPassedTestSuites":1,"numPassedTests":1,"numPendingTestSuites":0,"numPendingTests":0,"numRuntimeErrorTestSuites":0,"numTodoTests":0,"numTotalTestSuites":1,"numTotalTests":1,"openHandles":[],"snapshot":{"added":0,"didUpdate":false,"failure":false,"filesAdded":0,"filesRemoved":0,"filesRemovedList":[],"filesUnmatched":0,"filesUpdated":0,"matched":0,"total":0,"unchecked":0,"uncheckedKeysByFile":[],"unmatched":0,"updated":0},"startTime":1652277144912,"success":true,"testResults":[{"assertionResults":[{"ancestorTitles":["Google Fails"],"failureMessages":[],"fullName":"Google Fails that Google.com fails to find element","location":null,"status":"passed","title":"that Google.com fails to find element"}],"endTime":1652277145917,"message":"","name":"/tmp/runs/d72e45d8-348e-40fb-9d6f-db3dfb00ba1b/suites/google-fail-example.test.js","startTime":1652277145126,"status":"passed","summary":""}],"wasInterrupted":false}
{"level":"info","message":{"numFailedTestSuites":0,"numFailedTests":0,"numPassedTestSuites":1,"numPassedTests":1,"numPendingTestSuites":0,"numPendingTests":0,"numRuntimeErrorTestSuites":0,"numTodoTests":0,"numTotalTestSuites":1,"numTotalTests":1,"openHandles":[],"snapshot":{"added":0,"didUpdate":false,"failure":false,"filesAdded":0,"filesRemoved":0,"filesRemovedList":[],"filesUnmatched":0,"filesUpdated":0,"matched":0,"total":0,"unchecked":0,"uncheckedKeysByFile":[],"unmatched":0,"updated":0},"startTime":1652277144912,"success":true,"testResults":[{"failureMessage":null,"leaks":false,"numFailingTests":0,"numPassingTests":1,"numPendingTests":0,"numTodoTests":0,"openHandles":[],"perfStats":{"end":1652277145917,"runtime":791,"slow":false,"start":1652277145126},"skipped":false,"snapshot":{"added":0,"fileDeleted":false,"matched":0,"unchecked":0,"uncheckedKeys":[],"unmatched":0,"updated":0},"testFilePath":"/tmp/runs/d72e45d8-348e-40fb-9d6f-db3dfb00ba1b/suites/google-fail-example.test.js","testResults":[{"ancestorTitles":["Google Fails"],"duration":508,"failureDetails":[],"failureMessages":[],"fullName":"Google Fails that Google.com fails to find element","invocations":1,"location":null,"numPassingAsserts":0,"status":"passed","title":"that Google.com fails to find element"}]}],"wasInterrupted":false},"sanity_runner_version":"3.4.2"}
```