### PR TITLE
feat: update service docker image to node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM node:10.16.3-slim
-
-RUN sed '/jessie-updates/d' -i /etc/apt/sources.list
-RUN apt-get update && \
-    apt-get install -yq python-pip jq git unzip && \
-    pip install awscli

--- a/service/service.Dockerfile
+++ b/service/service.Dockerfile
@@ -1,5 +1,5 @@
 # Use aws lambda base image
-FROM public.ecr.aws/lambda/nodejs:14
+FROM public.ecr.aws/lambda/nodejs:16
 
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
 


### PR DESCRIPTION
Node 16 support released! https://aws.amazon.com/about-aws/whats-new/2022/05/aws-lambda-adds-support-node-js-16/