### PR TITLE
feat: allow force deletion of screenshot s3 bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,6 +45,7 @@ resource "null_resource" "push_image_to_ecr" {
  */
 resource "aws_s3_bucket" "s3_bucket" {
   bucket_prefix = "sanity-runner-bucket-"
+  force_destroy = true
 }
 
 


### PR DESCRIPTION
The s3 bucket is meant to store transient objects so it's safe to force destroy when the terraform stack is being cleaned up.