### PR TITLE
Support `pluginOutputs` in the test results

### DIFF
--- a/packages/plugins/fullstory/src/index.ts
+++ b/packages/plugins/fullstory/src/index.ts
@@ -1,6 +1,11 @@
-import type { BeforeBrowserCleanupContext, PluginHooks } from '@tophat/sanity-runner-types'
+import type {
+    BeforeBrowserCleanupContext,
+    OnTestCompleteContext,
+    PluginHooks,
+} from '@tophat/sanity-runner-types'
 
 const PluginName = 'FullStory Plugin'
+const PluginOutputKey = 'fullstory'
 
 let state: string | null = null
 
@@ -22,8 +27,19 @@ async function onBeforeBrowserCleanup(context: BeforeBrowserCleanupContext): Pro
     }
 }
 
+async function onTestComplete(context: OnTestCompleteContext): Promise<void> {
+    if (context.testVariables.FULLSTORY_ENABLED !== 'true') return
+    if (state) {
+        context.setPluginOutput(PluginOutputKey, {
+            url: state,
+        })
+    }
+}
+
 export default function FullStoryPlugin({
     beforeBrowserCleanup,
-}: Pick<PluginHooks, 'beforeBrowserCleanup'>): void {
+    onTestFailure,
+}: Pick<PluginHooks, 'beforeBrowserCleanup' | 'onTestFailure'>): void {
     beforeBrowserCleanup.tapPromise(PluginName, onBeforeBrowserCleanup)
+    onTestFailure.tapPromise(PluginName, onTestComplete)
 }

--- a/packages/plugins/fullstory/src/index.ts
+++ b/packages/plugins/fullstory/src/index.ts
@@ -28,7 +28,6 @@ async function onBeforeBrowserCleanup(context: BeforeBrowserCleanupContext): Pro
 }
 
 async function onTestComplete(context: OnTestCompleteContext): Promise<void> {
-    if (context.testVariables.FULLSTORY_ENABLED !== 'true') return
     if (state) {
         context.setPluginOutput(PluginOutputKey, {
             url: state,
@@ -39,7 +38,9 @@ async function onTestComplete(context: OnTestCompleteContext): Promise<void> {
 export default function FullStoryPlugin({
     beforeBrowserCleanup,
     onTestFailure,
-}: Pick<PluginHooks, 'beforeBrowserCleanup' | 'onTestFailure'>): void {
+    onTestSuccess,
+}: Pick<PluginHooks, 'beforeBrowserCleanup' | 'onTestFailure' | 'onTestSuccess'>): void {
     beforeBrowserCleanup.tapPromise(PluginName, onBeforeBrowserCleanup)
     onTestFailure.tapPromise(PluginName, onTestComplete)
+    onTestSuccess.tapPromise(PluginName, onTestComplete)
 }

--- a/packages/plugins/pagerduty/src/index.ts
+++ b/packages/plugins/pagerduty/src/index.ts
@@ -4,7 +4,7 @@ import { PluginInternals } from './plugin'
 
 const PluginName = 'PagerDuty Plugin'
 
-export default function SlackPlugin({
+export default function PagerDutyPlugin({
     onTestFailure,
     onTestSuccess,
 }: Pick<PluginHooks, 'onTestFailure' | 'onTestSuccess'>): void {

--- a/packages/service/src/core/runTest.ts
+++ b/packages/service/src/core/runTest.ts
@@ -65,6 +65,12 @@ export async function runTest(runTestContext: RunTestContext): Promise<InvokeRes
         delete global._sanityRunnerTestGlobals
 
         const response = await runner.format(results)
+        response.pluginOutputs = {}
+        const setPluginOutput = (name: string, outputValue: any) => {
+            if (response.pluginOutputs) {
+                response.pluginOutputs[name] = outputValue
+            }
+        }
         const context: OnTestCompleteContext<TestMetadata> = {
             logger,
             getSecretValue,
@@ -79,6 +85,7 @@ export async function runTest(runTestContext: RunTestContext): Promise<InvokeRes
 
             attempt: runTestContext.attempt,
             maxAttempts: runTestContext.maxAttempts,
+            setPluginOutput,
         }
 
         tracer?.scope().active()?.addTags({

--- a/packages/service/src/core/runTest.ts
+++ b/packages/service/src/core/runTest.ts
@@ -65,7 +65,6 @@ export async function runTest(runTestContext: RunTestContext): Promise<InvokeRes
         delete global._sanityRunnerTestGlobals
 
         const response = await runner.format(results)
-        response.pluginOutputs = {}
         const setPluginOutput = (name: string, outputValue: any) => {
             if (response.pluginOutputs) {
                 response.pluginOutputs[name] = outputValue

--- a/packages/service/src/core/runners/jest.ts
+++ b/packages/service/src/core/runners/jest.ts
@@ -275,6 +275,7 @@ export default class JestPuppeteerTestRunner {
             testResults: {
                 [path.basename(reportFilename)]: report,
             },
+            pluginOutputs: {},
         }
     }
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,6 +72,7 @@ export type InvokeResponsePayload = {
         name?: { name: string }
     }>
     testResults?: Record<JUnitReportFilename, JUnitReport>
+    pluginOutputs?: Record<string, any>
 }
 
 export type TestVariables = Partial<Record<string, string>>
@@ -111,6 +112,7 @@ export interface OnTestCompleteContext<M extends TestMetadata = TestMetadata>
 
     attempt: number
     maxAttempts: number
+    setPluginOutput: (outputName: string, outputValue: any) => void
 }
 
 export interface BeforeBrowserCleanupContext<M extends TestMetadata = TestMetadata>


### PR DESCRIPTION
- Add a function `setPluginOutput` to `OnTestCompleteContext`. This allows plugins to place custom output values to the test results.
- Add `pluginOutputs` to the test response to the client. This would enable future client plugins to make use of these outputs.